### PR TITLE
Update with-span, dependency updates, and more

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
-{:deps    {io.opentracing/opentracing-api  {:mvn/version "0.31.0"}
-           io.opentracing/opentracing-noop {:mvn/version "0.31.0"}
-           io.opentracing/opentracing-util {:mvn/version "0.31.0"}
+{:deps    {io.opentracing/opentracing-api  {:mvn/version "0.32.0"}
+           io.opentracing/opentracing-noop {:mvn/version "0.32.0"}
+           io.opentracing/opentracing-util {:mvn/version "0.32.0"}
            ring                            {:mvn/version "1.6.3"}}
  :paths   ["src/clj" "resources"]
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps  {io.opentracing/opentracing-mock "0.31.0"}}}}
+                  :extra-deps  {io.opentracing/opentracing-mock "0.32.0"}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps    {io.opentracing/opentracing-api  {:mvn/version "0.32.0"}
            io.opentracing/opentracing-noop {:mvn/version "0.32.0"}
            io.opentracing/opentracing-util {:mvn/version "0.32.0"}
-           ring                            {:mvn/version "1.6.3"}}
+           ring/ring-core                  {:mvn/version "1.7.1"}}
  :paths   ["src/clj" "resources"]
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps  {io.opentracing/opentracing-mock "0.32.0"}}}}

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :distribution :repo}
   :source-paths ["src/clj"]
   :plugins [[lein-codox "0.10.4"]]
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [io.opentracing/opentracing-api "0.32.0"]
                  [io.opentracing/opentracing-noop "0.32.0"]
                  [io.opentracing/opentracing-util "0.32.0"]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [io.opentracing/opentracing-api "0.32.0"]
                  [io.opentracing/opentracing-noop "0.32.0"]
                  [io.opentracing/opentracing-util "0.32.0"]
-                 [ring "1.6.3"]]
+                 [ring/ring-core "1.7.1"]]
   :codox {:output-path "codox"
           :metadata    {:doc/format :markdown}
           :source-uri  "https://github.com/alvinfrancis/opentracing-clj/blob/v{version}/{filepath}#L{line}"}

--- a/project.clj
+++ b/project.clj
@@ -7,12 +7,12 @@
   :source-paths ["src/clj"]
   :plugins [[lein-codox "0.10.4"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [io.opentracing/opentracing-api "0.31.0"]
-                 [io.opentracing/opentracing-noop "0.31.0"]
-                 [io.opentracing/opentracing-util "0.31.0"]
+                 [io.opentracing/opentracing-api "0.32.0"]
+                 [io.opentracing/opentracing-noop "0.32.0"]
+                 [io.opentracing/opentracing-util "0.32.0"]
                  [ring "1.6.3"]]
   :codox {:output-path "codox"
           :metadata    {:doc/format :markdown}
           :source-uri  "https://github.com/alvinfrancis/opentracing-clj/blob/v{version}/{filepath}#L{line}"}
-  :profiles {:test {:dependencies [[io.opentracing/opentracing-mock "0.31.0"]
+  :profiles {:test {:dependencies [[io.opentracing/opentracing-mock "0.32.0"]
                                    [ring/ring-mock "0.3.2"]]}})

--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,13 @@
             :distribution :repo}
   :source-paths ["src/clj"]
   :plugins [[lein-codox "0.10.4"]]
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [io.opentracing/opentracing-api "0.32.0"]
+  :dependencies [[io.opentracing/opentracing-api "0.32.0"]
                  [io.opentracing/opentracing-noop "0.32.0"]
                  [io.opentracing/opentracing-util "0.32.0"]
                  [ring/ring-core "1.7.1"]]
   :codox {:output-path "codox"
           :metadata    {:doc/format :markdown}
           :source-uri  "https://github.com/alvinfrancis/opentracing-clj/blob/v{version}/{filepath}#L{line}"}
-  :profiles {:test {:dependencies [[io.opentracing/opentracing-mock "0.32.0"]
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.0"]]}
+             :test {:dependencies [[io.opentracing/opentracing-mock "0.32.0"]
                                    [ring/ring-mock "0.3.2"]]}})

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -211,9 +211,9 @@
 
   span-init-spec must evaluate at runtime to a value conforming to
   the :opentracing/span-init spec."
-  [bindings & body]
-  (let [s (bindings 0)
-        m (bindings 1)]
+  [binding & body]
+  (let [s (binding 0)
+        m (binding 1)]
     `(let [m#  ~m
            ~s  (get-span* m#)]
        (try

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -172,7 +172,7 @@
           :span-spec any?)))
 
 (defn ^:private build-new-span
-  "Given a span-data, create and return a new span["
+  "Given a span-data, create and return a new span."
   ^Span [span-data]
   (let [builder (sb/build-span *tracer* (:name span-data))]
     (when-let [tags# (:tags span-data)]

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -216,20 +216,20 @@
         m (bindings 1)]
     `(let [m#  ~m
            ~s  (get-span* m#)]
-       (with-open [^Scope _# (.activate (.scopeManager *tracer*)
-                                        ~s)]
-         (try
-           ~@body
-           (catch Exception e#
-             (.set Tags/ERROR ~s true)
-             (.log ~s
-                   {Fields/EVENT "error"
-                    Fields/ERROR_OBJECT e#
-                    Fields/MESSAGE (.getMessage e#)})
-             (throw e#))
-           (finally
-             (when (:finish? m# true)
-               (.finish ~s))))))))
+       (try
+         (with-open [^Scope _# (.activate (.scopeManager *tracer*)
+                                          ~s)]
+           ~@body)
+         (catch Exception e#
+           (.set Tags/ERROR ~s true)
+           (.log ~s
+                 {Fields/EVENT "error"
+                  Fields/ERROR_OBJECT e#
+                  Fields/MESSAGE (.getMessage e#)})
+           (throw e#))
+         (finally
+           (when (:finish? m# true)
+             (.finish ~s)))))))
 
 (s/fdef with-span
   :args (s/cat :binding :opentracing/span-binding

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -7,6 +7,8 @@
    [opentracing-clj.span-builder :as sb]
    [ring.util.request])
   (:import (io.opentracing Span SpanContext Tracer Scope)
+           (io.opentracing.log Fields)
+           (io.opentracing.tag Tags)
            (io.opentracing.util GlobalTracer)))
 
 (def ^:dynamic ^Tracer *tracer*
@@ -200,6 +202,13 @@
                                                   ~s)]
                    (try
                      ~@body
+                     (catch Exception e#
+                       (.set Tags/ERROR ~s true)
+                       (.log ~s
+                             {Fields/EVENT "error"
+                              Fields/ERROR_OBJECT e#
+                              Fields/MESSAGE (.getMessage e#)})
+                       (throw e#))
                      (finally
                        (when (:finish? m# true)
                          (.finish ~s)))))))
@@ -210,6 +219,13 @@
                                                 ~s)]
                  (try
                    ~@body
+                   (catch Exception e#
+                     (.set Tags/ERROR ~s true)
+                     (.log ~s
+                           {Fields/EVENT "error"
+                            Fields/ERROR_OBJECT e#
+                            Fields/MESSAGE (.getMessage e#)})
+                     (throw e#))
                    (finally
                      (when (:finish? m# true)
                        (.finish ~s))))))

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -22,7 +22,7 @@
   "Returns the current active span."
   []
   (when *tracer*
-    (.activeSpan *tracer*)))
+    (.activeSpan (.scopeManager *tracer*))))
 
 (defmacro with-active-span
   "Convenience macro for setting sym to the current active span.  Will

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -189,7 +189,7 @@
   :args (s/cat :span-data :opentracing/span-data)
   :ret :opentracing/span)
 
-(defn get-span
+(defn ^:internal get-span*
   "Given a span-init, return the existing or new span."
   [span-init]
   (let [conformed-span-init (s/conform :opentracing/span-init span-init)]
@@ -200,7 +200,7 @@
         :new (build-new-span span-init)
         :existing (:from span-init)))))
 
-(s/fdef get-span
+(s/fdef get-span*
   :args (s/cat :span-init :opentracing/span-init)
   :ret :opentracing/span)
 
@@ -215,7 +215,7 @@
   (let [s (bindings 0)
         m (bindings 1)]
     `(let [m#  ~m
-           ~s  (get-span m#)]
+           ~s  (get-span* m#)]
        (with-open [^Scope _# (.activate (.scopeManager *tracer*)
                                         ~s)]
          (try

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -193,7 +193,7 @@
   :args (s/cat :span-data :opentracing/span-data)
   :ret :opentracing/span)
 
-(defn ^:internal get-span*
+(defn ^:internal ^:no-doc get-span*
   "Given a span-init, return the existing or new span."
   [span-init]
   (let [conformed-span-init (s/conform :opentracing/span-init span-init)]

--- a/src/clj/opentracing_clj/span_builder.clj
+++ b/src/clj/opentracing_clj/span_builder.clj
@@ -38,7 +38,9 @@
   [^Tracer$SpanBuilder sb timestamp]
   (.withStartTimestamp sb timestamp))
 
-(defn start
+(defn ^:deprecated start
+  "**DEPRECATED**  The underlying API has been deprecated.  Just call
+  `(.start sb)` instead."
   ([^Tracer$SpanBuilder sb finish-on-close?]
    (.startActive sb finish-on-close?)))
 

--- a/test/opentracing_clj/core_test.clj
+++ b/test/opentracing_clj/core_test.clj
@@ -219,19 +219,18 @@
 
     (testing "existing span"
       (.reset *tracer*)
-      (let [s1        (-> *tracer* (.buildSpan "test") (.start))
+      (let [s1        (-> *tracer* (.buildSpan "test1") (.start))
             process-1 (future
                         (with-span [t {:from s1}]
-                          (is (= s1 (.activeSpan *tracer*))))
-                        (is (= 1 (count (.finishedSpans *tracer*)))))
-            s2        (-> *tracer* (.buildSpan "test") (.start))
+                          (is (= s1 (.activeSpan *tracer*)))))
+            s2        (-> *tracer* (.buildSpan "test2") (.start))
             process-2 (future
                         (with-span [t {:from    s2
                                        :finish? false}]
-                          (is (= s2 (.activeSpan *tracer*))))
-                        (is (= 1 (count (.finishedSpans *tracer*)))))]
+                          (is (= s2 (.activeSpan *tracer*)))))]
         @process-1
-        @process-2))
+        @process-2
+        (is (= 1 (count (.finishedSpans *tracer*))))))
 
     (testing "ambiguous spec"
       (.reset *tracer*)

--- a/test/opentracing_clj/core_test.clj
+++ b/test/opentracing_clj/core_test.clj
@@ -242,5 +242,6 @@
                        (with-span [t {:name "new"
                                       :from existing}]
                          (is (= existing (.activeSpan *tracer*))))
-                       (is (= 1 (count (.finishedSpans *tracer*)))))]
-        process))))
+                       )]
+        @process
+        (is (= 1 (count (.finishedSpans *tracer*))))))))

--- a/test/opentracing_clj/core_test.clj
+++ b/test/opentracing_clj/core_test.clj
@@ -248,47 +248,133 @@
 
     (testing "failing spans"
       (testing "a new span"
-        (.reset *tracer*)
-        (let [span-name "boom"
-              error (Exception. "BOOM!")]
-          (is (thrown? Exception
-                       (with-span [s {:name span-name}]
-                         (throw error))))
-          (is (= 1 (count (.finishedSpans *tracer*))))
-          (let [finished-span (first (.finishedSpans *tracer*))
-                tags (.tags finished-span)
-                log-entries (.logEntries finished-span)]
-            (is (= span-name (.operationName finished-span))
-                "span with correct name finished")
-            (is (true? (get tags "error"))
-                "error tag is present on finished span")
-            (is (= 1 (count log-entries))
-                "a log entry is present")
-            (is (= {"event" "error"
-                    "error.object" error
-                    "message" "BOOM!"}
-                   (.fields (first log-entries)))
-                "log entry has correct fields"))))
+        (testing "default option"
+          (.reset *tracer*)
+          (let [span-name "boom"
+                error (Exception. "BOOM!")]
+            (is (thrown? Exception
+                         (with-span [_ {:name span-name}]
+                           (throw error))))
+            (is (= 1 (count (.finishedSpans *tracer*))))
+            (let [finished-span (first (.finishedSpans *tracer*))
+                  tags (.tags finished-span)
+                  log-entries (.logEntries finished-span)]
+              (is (= span-name (.operationName finished-span))
+                  "span with correct name finished")
+              (is (true? (get tags "error"))
+                  "error tag is present on finished span")
+              (is (= 1 (count log-entries))
+                  "a log entry is present")
+              (is (= {"event" "error"
+                      "error.object" error
+                      "message" "BOOM!"}
+                     (.fields (first log-entries)))
+                  "log entry has correct fields"))))
+        (testing "explicitly process exceptions"
+          (.reset *tracer*)
+          (let [span-name "boom"
+                error (Exception. "BOOM!")]
+            (is (thrown? Exception
+                         (with-span [_ {:name span-name
+                                        :process-exceptions? true}]
+                           (throw error))))
+            (is (= 1 (count (.finishedSpans *tracer*))))
+            (let [finished-span (first (.finishedSpans *tracer*))
+                  tags (.tags finished-span)
+                  log-entries (.logEntries finished-span)]
+              (is (= span-name (.operationName finished-span))
+                  "span with correct name finished")
+              (is (true? (get tags "error"))
+                  "error tag is present on finished span")
+              (is (= 1 (count log-entries))
+                  "a log entry is present")
+              (is (= {"event" "error"
+                      "error.object" error
+                      "message" "BOOM!"}
+                     (.fields (first log-entries)))
+                  "log entry has correct fields"))))
+        (testing "don't process exceptions"
+          (.reset *tracer*)
+          (let [span-name "boom"
+                error (Exception. "BOOM!")]
+            (is (thrown? Exception
+                         (with-span [_ {:name span-name
+                                        :process-exceptions? false}]
+                           (throw error))))
+            (is (= 1 (count (.finishedSpans *tracer*))))
+            (let [finished-span (first (.finishedSpans *tracer*))
+                  tags (.tags finished-span)
+                  log-entries (.logEntries finished-span)]
+              (is (= span-name (.operationName finished-span))
+                  "span with correct name finished")
+              (is (not (contains? tags "error"))
+                  "no error tag is present on finished span")
+              (is (zero? (count log-entries))
+                  "no log entry is present")))))
       (testing "from an existing span"
-        (.reset *tracer*)
-        (let [span-name "boom"
-              existing (.start (.buildSpan *tracer* span-name))
-              error (Exception. "BOOM!")]
-          (is (thrown? Exception
-                       (with-span [s {:from existing}]
-                         (throw error))))
-          (is (= 1 (count (.finishedSpans *tracer*))))
-          (let [finished-span (first (.finishedSpans *tracer*))
-                tags (.tags finished-span)
-                log-entries (.logEntries finished-span)]
-            (is (= span-name (.operationName finished-span))
-                "span with correct name finished")
-            (is (true? (get tags "error"))
-                "error tag is present on finished span")
-            (is (= 1 (count log-entries))
-                "a log entry is present")
-            (is (= {"event" "error"
-                    "error.object" error
-                    "message" "BOOM!"}
-                   (.fields (first log-entries)))
-                "log entry has correct fields")))))))
+        (testing "default option"
+          (.reset *tracer*)
+          (let [span-name "boom"
+                existing (.start (.buildSpan *tracer* span-name))
+                error (Exception. "BOOM!")]
+            (is (thrown? Exception
+                         (with-span [_ {:from existing}]
+                           (throw error))))
+            (is (= 1 (count (.finishedSpans *tracer*))))
+            (let [finished-span (first (.finishedSpans *tracer*))
+                  tags (.tags finished-span)
+                  log-entries (.logEntries finished-span)]
+              (is (= span-name (.operationName finished-span))
+                  "span with correct name finished")
+              (is (true? (get tags "error"))
+                  "error tag is present on finished span")
+              (is (= 1 (count log-entries))
+                  "a log entry is present")
+              (is (= {"event" "error"
+                      "error.object" error
+                      "message" "BOOM!"}
+                     (.fields (first log-entries)))
+                  "log entry has correct fields"))))
+        (testing "explicitly process exceptions"
+          (.reset *tracer*)
+          (let [span-name "boom"
+                existing (.start (.buildSpan *tracer* span-name))
+                error (Exception. "BOOM!")]
+            (is (thrown? Exception
+                         (with-span [_ {:from existing
+                                        :process-exceptions? true}]
+                           (throw error))))
+            (is (= 1 (count (.finishedSpans *tracer*))))
+            (let [finished-span (first (.finishedSpans *tracer*))
+                  tags (.tags finished-span)
+                  log-entries (.logEntries finished-span)]
+              (is (= span-name (.operationName finished-span))
+                  "span with correct name finished")
+              (is (true? (get tags "error"))
+                  "error tag is present on finished span")
+              (is (= 1 (count log-entries))
+                  "a log entry is present")
+              (is (= {"event" "error"
+                      "error.object" error
+                      "message" "BOOM!"}
+                     (.fields (first log-entries)))
+                  "log entry has correct fields"))))
+        (testing "don't process exceptions"
+          (.reset *tracer*)
+          (let [span-name "boom"
+                existing (.start (.buildSpan *tracer* span-name))
+                error (Exception. "BOOM!")]
+            (is (thrown? Exception
+                         (with-span [_ {:from existing
+                                        :process-exceptions? false}]
+                           (throw error))))
+            (is (= 1 (count (.finishedSpans *tracer*))))
+            (let [finished-span (first (.finishedSpans *tracer*))
+                  tags (.tags finished-span)
+                  log-entries (.logEntries finished-span)]
+              (is (= span-name (.operationName finished-span))
+                  "span with correct name finished")
+              (is (not (contains? tags "error"))
+                  "error tag is not present on finished span")
+              (is (zero? (count log-entries))
+                  "a log entry is not present"))))))))

--- a/test/opentracing_clj/span_builder_test.clj
+++ b/test/opentracing_clj/span_builder_test.clj
@@ -104,7 +104,7 @@
         (is (= ms (.startMicros (.span scope))))))))
 
 (deftest start-test
-  (testing "start"
+  (testing "deprecated start"
     (is (= 0 (do (with-open [scope (-> (-> *tracer* (.buildSpan "test")) (start false))])
                  (count (.finishedSpans *tracer*)))))
     (.reset *tracer*)


### PR DESCRIPTION
Added:

* Added option to `with-span`: `:process-exceptions?` (defaults to true).  If true, any exceptions thrown within the `with-span` block will be caught, added to the span as a log entry, and rethrown.  Additionally, the `error` tag will be added to the span.  Set to false to restore the old behaviour.

Changed:

* Dependency updates:
  * Opentracing to 0.32.0
  * ring 1.6.3 to ring-core 1.7.1
  * Clojure to 1.10.0 as a provided dependency
* `opentracing-clj.span-builder/start` is deprecated

Fixed:

* Fixed non-deterministic tests
* Nesting `wrap-opentracing` middleware will no longer create multiple spans.
