### PR TITLE
fixes child-of spec

### DIFF
--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -142,8 +142,8 @@
 (s/def :opentracing.span-data/ignore-active? boolean?)
 (s/def :opentracing.span-data/timestamp :opentracing/microseconds-since-epoch)
 (s/def :opentracing.span-data/child-of (s/nilable
-                                        (s/or :opentracing/span
-                                              :opentracing/span-context)))
+                                        (s/or :span :opentracing/span
+                                              :span-context :opentracing/span-context)))
 (s/def :opentracing.span-data/finish? boolean?)
 
 (s/def :opentracing/span-data


### PR DESCRIPTION
`s/or` is miswritten here, in the end only allowing a `SpanContext`. I was scratching my head on the error from within `with-span` for a while on this one :D