### PR TITLE
Fixes ClassCastException for TextMapExtractAdapter -> TextMap

### DIFF
--- a/src/clj/opentracing_clj/propagation.clj
+++ b/src/clj/opentracing_clj/propagation.clj
@@ -3,7 +3,7 @@
   (:require [opentracing-clj.core :as tracing])
   (:import (io.opentracing SpanContext)
            (io.opentracing.propagation Format$Builtin
-                                       TextMapExtractAdapter
+                                       TextMapAdapter
                                        TextMapInjectAdapter)))
 
 (def formats {:http Format$Builtin/HTTP_HEADERS
@@ -30,5 +30,5 @@
   [^java.util.Map carrier format]
   (when-let [t tracing/*tracer*]
     (let [hm (java.util.HashMap. carrier)
-          tm (TextMapExtractAdapter. hm)]
+          tm (TextMapAdapter. hm)]
       (.extract t (get formats format) tm))))


### PR DESCRIPTION
This error occurs due to API drift in OpenTracing's Java API between v0.31.0 and v0.32.0 where the hierarchy changed for `TextMap` and `TextMapExtractor`.  This combined with the formats changing generics results in a runtime `ClassCastException` due to the expected type in the generics.

Please forgive a lack of a test, I am relatively new to Clojure and I am not yet sure why the tests did not catch this.  If you would like tests and are willing to hold my hand through writing tests I would be happy to add them.