### PR TITLE
Add support for using io.opentracing.tag Tags directly, support keywords

### DIFF
--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -131,7 +131,6 @@
    (cond
      (instance? Boolean value) (.setTag span ^String (resolve-tag-key key) ^Boolean value)
      (instance? Number value)  (.setTag span ^String (resolve-tag-key key) ^Number value)
-     (instance? Tag value)     (.setTag span ^String (resolve-tag-key key) ^String (.getKey ^Tag value))
      :else                     (.setTag span ^String (resolve-tag-key key) ^String (str value)))))
 
 (defn set-tags

--- a/src/clj/opentracing_clj/core.clj
+++ b/src/clj/opentracing_clj/core.clj
@@ -5,7 +5,7 @@
    [clojure.walk :as walk]
    [opentracing-clj.span-builder :as sb]
    [ring.util.request])
-  (:import (io.opentracing Span SpanContext Tracer Scope)
+  (:import (io.opentracing Span SpanContext Tracer Scope ScopeManager)
            (io.opentracing.tag Tag)
            (io.opentracing.util GlobalTracer)))
 
@@ -17,9 +17,9 @@
 
 (defn scope-manager
   "Returns the ScopeManager of the tracer."
-  ([]
+  (^ScopeManager []
    (.scopeManager *tracer*))
-  ([^Tracer tracer]
+  (^ScopeManager [^Tracer tracer]
    (.scopeManager tracer)))
 
 ;; Span

--- a/test/opentracing_clj/core_test.clj
+++ b/test/opentracing_clj/core_test.clj
@@ -260,7 +260,6 @@
                       Tags/ERROR            true
                       Tags/DB_TYPE          "postgres"
                       Tags/SPAN_KIND         Tags/SPAN_KIND_CLIENT
-                      "tag-key-string-value" Tags/SPAN_KIND_CLIENT
                       "boolean"              true
                       "number"               1
                       "object"               {:some :map}}

--- a/test/opentracing_clj/core_test.clj
+++ b/test/opentracing_clj/core_test.clj
@@ -4,6 +4,7 @@
             [opentracing-clj.core :refer :all]
             [opentracing-clj.test-utils :as utils])
   (:import [io.opentracing References]
+           [io.opentracing.tag Tags]
            [io.opentracing.mock MockSpan MockTracer]))
 
 (use-fixtures :each utils/with-mock-tracer)
@@ -228,13 +229,23 @@
                                   (get (.tags span) "key"))))
             (is (= "passed" (do (set-tag "key" "passed")
                                 (get (.tags span) "key"))))
+            (is (= "passed" (do (set-tag :key "passed")
+                                (get (.tags span) "key"))))
+            (is (= "passed" (do (set-tag :namespaced.key "passed")
+                                (get (.tags span) "namespaced.key"))))
             (is (= true (do (set-tag "boolean" true)
                             (get (.tags span) "boolean"))))
             (is (= 1 (do (set-tag "number" 1)
                          (get (.tags span) "number"))))
+            (is (= true (do (set-tag Tags/ERROR true)
+                            (get (.tags span) "error"))))
+            (is (= "client" (do (set-tag Tags/SPAN_KIND Tags/SPAN_KIND_CLIENT)
+                                (get (.tags span) "span.kind"))))
+            (is (= "client" (do (set-tag "span.kind" Tags/SPAN_KIND_CLIENT)
+                                (get (.tags span) "span.kind"))))
             (is (= "{:some :map}" (do (set-tag "map" {:some :map})
                                       (get (.tags span) "map"))))
-            (is (thrown? ClassCastException (set-tag :not-string-key "key-val"))))
+            (is (thrown? ClassCastException (set-tag 123 "key-val"))))
           (finally
             (.finish span)))))
 
@@ -244,16 +255,24 @@
 (deftest set-tags-test
   (testing "set-tags"
     (testing "active span"
-      (let [in-tags  {"string-key" "string-val"
-                      :keyword-key :key-val
-                      "boolean"    true
-                      "number"     1
-                      "object"     {:some :map}}
-            out-tags {"string-key"  "string-val"
-                      "keyword-key" ":key-val"
-                      "boolean"     true
-                      "number"      1
-                      "object"      "{:some :map}"}]
+      (let [in-tags  {"string-key"          "string-val"
+                      :keyword-key          :key-val
+                      Tags/ERROR            true
+                      Tags/DB_TYPE          "postgres"
+                      Tags/SPAN_KIND         Tags/SPAN_KIND_CLIENT
+                      "tag-key-string-value" Tags/SPAN_KIND_CLIENT
+                      "boolean"              true
+                      "number"               1
+                      "object"               {:some :map}}
+            out-tags {"string-key"           "string-val"
+                      "keyword-key"          ":key-val"
+                      "error"                true
+                      "db.type"              "postgres"
+                      "span.kind"            "client"
+                      "tag-key-string-value" "client"
+                      "boolean"               true
+                      "number"                1
+                      "object"                "{:some :map}"}]
         (let [span (.. *tracer* (buildSpan "test") (start))]
           (try
             (with-open [scope (.. *tracer* (scopeManager) (activate span))]
@@ -347,8 +366,7 @@
                        ;; should choose to use the existing span spec
                        (with-span [t {:name "new"
                                       :from existing}]
-                         (is (= existing (.activeSpan *tracer*))))
-                       )]
+                         (is (= existing (.activeSpan *tracer*)))))]
         @process
         (is (= 1 (count (.finishedSpans *tracer*))))))
 


### PR DESCRIPTION
This allows easier use of the convenients specified here https://github.com/opentracing/specification/blob/master/semantic_conventions.md by using the static variables here: https://github.com/opentracing/opentracing-java/blob/master/opentracing-api/src/main/java/io/opentracing/tag/Tags.java.

Has the side-effect of supporting keywords directly on `set-tag` (this includes new test cases).

Additionally fixed some minor reflection warnings:

```
Reflection warning, opentracing_clj/core.clj:23:4 - reference to field scopeManager can't be resolved.
Reflection warning, opentracing_clj/core.clj:32:5 - reference to field activeSpan can't be resolved.
Reflection warning, opentracing_clj/core.clj:44:3 - call to method activate can't be resolved (target class is unknown).
```