### PR TITLE
Add clj-kondo config for opentracing-clj.core/with-span

### DIFF
--- a/resources/clj-kondo.exports/opentracing-clj/config.edn
+++ b/resources/clj-kondo.exports/opentracing-clj/config.edn
@@ -1,0 +1,1 @@
+{:linters {:unresolved-symbol {:exclude [(opentracing-clj.core/with-span [s])]}}}


### PR DESCRIPTION
[clj-kondo](https://github.com/clj-kondo) is a now fairly widely used linter used within a number of projects, including [clj-lsp](https://github.com/clojure-lsp/clojure-lsp).

This should be used by clj-kondo to import configuration and avoid misreporting issues when using with-span:

![Screenshot 2021-02-20 181009](https://user-images.githubusercontent.com/3199181/108604616-e9404200-73a6-11eb-9b5d-f939568b0a5a.png)

Refer to the documentation for how clj-kondo discovers this from the classpath https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting-and-importing-configuration

My presumption is this will work despite not having a project namespace, see the implementation lines which will still locate the directory correctly: https://github.com/clj-kondo/clj-kondo/blob/510613e90d99165193c8cdb0f2f9913f5d0ed9b7/src/clj_kondo/impl/core.clj#L175-L185